### PR TITLE
Change it to work with latest pyparsing

### DIFF
--- a/ucsmsdk/ucsfilter.py
+++ b/ucsmsdk/ucsfilter.py
@@ -146,7 +146,7 @@ class ParseFilter(object):
             self.parse_filter_obj).setResultsName("semi_expression")
 
         expr = pp.Forward()
-        expr << pp.operatorPrecedence(semi_expression, [
+        expr << pp.infix_notation(semi_expression, [
             ("not", 1, pp.opAssoc.RIGHT, self.not_operator),
             ("and", 2, pp.opAssoc.LEFT, self.and_operator),
             ("or", 2, pp.opAssoc.LEFT, self.or_operator)


### PR DESCRIPTION
Latest version of Pyparsing package is downloaded each time as part of the building it.  Pyparsing versions above 3.0.X requires python version higher than 3.6.X. One of the syntax had to be changed is operator precedence. 

https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_0_0.html#other-discontinued-features